### PR TITLE
feat: add clang-tidy as a linter in unit testing via rules_lint

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -22,7 +22,7 @@
 #   revert:   Reverts a previous commit
 # ---------------------------------------------------------
 # Guidelines:
-# - Limit the subject line to 50 characters
+# - Limit the subject line to 80 characters
 # - Use the imperative mood (e.g., "Add feature" not "Added feature")
 # - Separate subject from body with a blank line
 # - Wrap the body at 72 characters

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,3 +1,6 @@
 formatter:
   indent: 2
   indentless_arrays: true
+ignore:
+- .clang-tidy
+- third_party/cpp/.clang-tidy

--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 gazelle(name = "gazelle")
 
 exports_files([
+    ".clang-tidy",
     ".rustfmt.toml",
     "pyproject.toml",
 ])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ module(
 # keep-sorted start
 bazel_dep(name = "aspect_rules_lint", version = "2.5.2")
 bazel_dep(name = "bazel_lib", version = "3.2.2")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gazelle", version = "0.47.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 # keep-sorted end

--- a/projects/cpp/greeter/BUILD
+++ b/projects/cpp/greeter/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//tools/lint:linters.bzl", "clang_tidy_test")
 
 cc_library(
     name = "greeter",
@@ -17,4 +18,9 @@ cc_test(
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
+)
+
+clang_tidy_test(
+    name = "clang_tidy",
+    srcs = [":greeter"],
 )

--- a/projects/cpp/greeter/greeter.h
+++ b/projects/cpp/greeter/greeter.h
@@ -4,6 +4,6 @@
 
 namespace projects::cpp::greeter {
 
-auto greet(const std::string &name = "World") -> std::string;
+std::string greet(const std::string &name = "World");
 
 } // namespace projects::cpp::greeter

--- a/projects/cpp/hello_world/BUILD
+++ b/projects/cpp/hello_world/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("//tools/lint:linters.bzl", "clang_tidy_test")
 
 cc_binary(
     name = "hello_world",
@@ -17,4 +18,9 @@ cc_test(
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
+)
+
+clang_tidy_test(
+    name = "clang_tidy",
+    srcs = [":hello_world"],
 )

--- a/third_party/cpp/.clang-tidy
+++ b/third_party/cpp/.clang-tidy
@@ -1,8 +1,7 @@
 Checks: >
-  -*, clang-analyzer-*, bugprone-*, cppcoreguidelines-*, modernize-*, performance-*, readability-*, portability-*
+  bugprone-*, -bugprone-exception-escape, clang-analyzer-*, -clang-diagnostic-builtin-macro-redefined, cppcoreguidelines-*, modernize-*, -modernize-use-trailing-return-type, performance-*, portability-*, -portability-avoid-pragma-once, readability-*
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 ExcludeHeaderFilterRegex: '^external/'
 HeaderFilterRegex: '^projects/cpp/.*'
-ExcludePaths: '(^|/)(external)(/|$)'
 UseColor: true

--- a/third_party/cpp/cpp_deps.MODULE.bazel
+++ b/third_party/cpp/cpp_deps.MODULE.bazel
@@ -45,7 +45,7 @@ llvm.sysroot(
     targets = ["linux-x86_64"],
 )
 use_repo(llvm, "llvm_toolchain")
-# use_repo(llvm, "llvm_toolchain_llvm") # if you depend on specific tools in scripts
+use_repo(llvm, "llvm_toolchain_llvm")  # if you depend on specific tools in scripts
 
 register_toolchains("@llvm_toolchain//:all")
 

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -5,9 +5,27 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 """
 
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 
 package(default_visibility = ["//:__subpackages__"])
+
+native_binary(
+    name = "clang_tidy",
+    src = select(
+        {
+            "@bazel_tools//src/conditions:linux_x86_64": "@llvm_toolchain_llvm//:bin/clang-tidy",
+            "@bazel_tools//src/conditions:linux_aarch64": "@llvm_toolchain_llvm//:bin/clang-tidy",
+            "@bazel_tools//src/conditions:darwin_x86_64": "@llvm_toolchain_llvm//:bin/clang-tidy",
+            "@bazel_tools//src/conditions:darwin_arm64": "@llvm_toolchain_llvm//:bin/clang-tidy",
+            # llvm_toolchain doesn't support windows: https://github.com/bazel-contrib/toolchains_llvm/issues/4
+            # as a workaround, you can download exes from
+            # https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.6 and make available locally.
+            "@bazel_tools//src/conditions:windows_x64": "clang-tidy.exe",
+        },
+    ),
+    out = "clang_tidy",
+)
 
 # py_console_script_binary(
 #     name = "bandit",

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -1,6 +1,8 @@
 """Define Python linter aspects"""
 
 # load("@aspect_rules_lint//lint:bandit.bzl", "lint_bandit_aspect")
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+
 # load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:pydoclint.bzl", "lint_pydoclint_aspect")
@@ -14,6 +16,18 @@ load("@aspect_rules_lint//lint:pydoclint.bzl", "lint_pydoclint_aspect")
 # )
 
 # bandit_test = lint_test(aspect = bandit)
+
+clang_tidy = lint_clang_tidy_aspect(
+    binary = Label("//tools/lint:clang_tidy"),
+    configs = [
+        Label("//:.clang-tidy"),
+    ],
+    lint_target_headers = True,
+    angle_includes_are_system = False,
+    verbose = False,
+)
+
+clang_tidy_test = lint_test(aspect = clang_tidy)
 
 # flake8 = lint_flake8_aspect(
 #     binary = Label("//tools/lint:flake8"),


### PR DESCRIPTION
* Add clang-tidy in unit tests
* Add clang-tidy tests in greeter and hello-world