### PR TITLE
chore: add clang-tidy unit test check for abseil example

### DIFF
--- a/projects/cpp/abseil/BUILD
+++ b/projects/cpp/abseil/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("//tools/lint:linters.bzl", "clang_tidy_test")
 
 cc_library(
     name = "abseil_example_lib",
@@ -27,4 +28,9 @@ cc_test(
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
+)
+
+clang_tidy_test(
+    name = "clang_tidy",
+    srcs = [":abseil_example"],
 )

--- a/projects/cpp/abseil/main.cpp
+++ b/projects/cpp/abseil/main.cpp
@@ -29,6 +29,8 @@ int main(int argc, char *argv[]) {
 
   std::vector<std::string> items = {"apple", "banana", "cherry"};
   std::string result = projects::cpp::abseil::JoinItems(items);
-  spdlog::info("Joined string: {}", result);
+  spdlog::info(
+      "Joined string: {}",
+      result); // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject)
   return 0;
 }

--- a/projects/cpp/abseil/main.cpp
+++ b/projects/cpp/abseil/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::string> items = {"apple", "banana", "cherry"};
   std::string result = projects::cpp::abseil::JoinItems(items);
   spdlog::info(
-      "Joined string: {}",
-      result); // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject)
+      "Joined string: {}", // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject)
+      result);
   return 0;
 }

--- a/third_party/cpp/.clang-tidy
+++ b/third_party/cpp/.clang-tidy
@@ -1,5 +1,5 @@
 Checks: >
-  bugprone-*, -bugprone-exception-escape, clang-analyzer-*, -clang-diagnostic-builtin-macro-redefined, cppcoreguidelines-*, modernize-*, -modernize-use-trailing-return-type, performance-*, portability-*, -portability-avoid-pragma-once, readability-*
+  bugprone-*, -bugprone-exception-escape, clang-analyzer-*, -clang-diagnostic-builtin-macro-redefined, cppcoreguidelines-*, -cppcoreguidelines-avoid-non-const-global-variables, modernize-*, -modernize-use-trailing-return-type, performance-*, portability-*, -portability-avoid-pragma-once, readability-*
 
 WarningsAsErrors: '*'
 ExcludeHeaderFilterRegex: '^external/'


### PR DESCRIPTION
Add clang-tidy unit test check for abseil example